### PR TITLE
Adding test data for the B1MG demonstrator

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,4 @@
 [submodule "data"]
 	path = data
 	url = https://github.com/NBISweden/ejprd-data.git
+	branch = feat/beaconize_data

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "config/gdi-starter-kit/starter-kit-storage-and-interfaces"]
 	path = config/gdi-starter-kit/starter-kit-storage-and-interfaces
 	url = https://github.com/GenomicDataInfrastructure/starter-kit-storage-and-interfaces.git
+[submodule "data"]
+	path = data
+	url = https://github.com/NBISweden/ejprd-data.git

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # EJP-RD - NBIS demo setup
 
+**Note**: This repository contains serveral `git submodules` that lock in specific versions of data and configurations located in other repositories. When you have used `git clone` or `git checkout _____` please remember to update the submodules.
+
+```{sh}
+git submodule update
+```
+
 ## Running using docker-compose
 ### Common preparation
 Create persistent docker networks that can be used to connect services:
@@ -14,7 +20,6 @@ docker network create ejprd-secure
 Run the following commands or see documentation for [htsget](docs/htsget.md) and [storage and interfaces](docs/storage-and-interfaces.md) configuration and usage:
 
 ```{sh}
-git submodule update
 docker compose --project-directory config/gdi-starter-kit up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Note**: This repository contains serveral `git submodules` that lock in specific versions of data and configurations located in other repositories. When you have used `git clone` or `git checkout _____` please remember to update the submodules.
 
 ```{sh}
+git submodule init
 git submodule update
 ```
 

--- a/config/gdi-starter-kit/config/beacon.env
+++ b/config/gdi-starter-kit/config/beacon.env
@@ -1,0 +1,3 @@
+SECRET_KEY="your_permissions_ui_secret_key"
+OIDC_RP_CLIENT_ID='your_client_id'
+OIDC_RP_CLIENT_SECRET='your_client_secret'

--- a/config/gdi-starter-kit/config/beacon_conf.py
+++ b/config/gdi-starter-kit/config/beacon_conf.py
@@ -1,0 +1,99 @@
+"""Beacon Configuration."""
+# Beacon general info
+beacon_id = 'org.nbis-ejprd.ga4gh-approval-beacon-test'
+beacon_name = 'EJPRD Swedish Test Beacon'
+api_version = 'v2.0.0'
+uri = 'https://beacon:5050/api/'
+default_beacon_granularity = 'record'
+max_beacon_granularity = 'record'
+
+#  Organization info
+org_id = 'NBIS'  # Id of the organization
+org_name = 'National Bioinformatics Infrastructure Sweden (NBIS)'  # Full name
+org_description = ('NBIS is a distributed national bioinformatics infrastructure, supporting life sciences in Sweden.')
+org_adress = ('Uppsala Biomedicine Center (BMC) '
+              'Husargatan 3, '
+              '751 23 Uppsala, Sweden')
+org_welcome_url = 'https://nbis.se/'
+org_contact_url = 'mailto:info@gdi.nbis.se'
+org_logo_url = 'https://nbis.se/nbislogo-green.svg'
+org_info = ''
+
+# Project info
+description = r"This Beacon is based on the GA4GH Beacon v2.0"
+version = 'v2.0'
+welcome_url = 'https://beacon:5050/api'
+alternative_url = 'https://beacon:5050/api'
+create_datetime = '2024-04-01T12:00:00Z'
+update_datetime = ''
+
+# Service
+service_type = 'org.ga4gh:beacon:1.0.0'  # service type
+service_url = 'https://beacon.ega-archive.org/api/services'
+entry_point = False
+is_open = True
+documentation_url = 'https://github.com/EGA-archive/beacon-2.x/'  # Documentation of the service
+environment = 'staging'  # Environment (production, development or testing/staging deployments)
+
+# GA4GH
+ga4gh_service_type_group = 'org.ga4gh'
+ga4gh_service_type_artifact = 'beacon'
+ga4gh_service_type_version = '1.0'
+
+# Beacon handovers
+beacon_handovers = {
+  'handoverType': {
+      'id': 'CUSTOM:000001',
+      'label': 'Project description'
+  },
+  'note': 'Project description',
+  'url': 'https://www.nist.gov/programs-projects/genome-bottle'
+}
+
+# CORS
+cors_hosts = [
+    "https://beacon-network-demo.ega-archive.org",
+]
+
+# database_schema = 'public' # comma-separated list of schemas
+# database_app_name = 'beacon-appname' # Useful to track connections
+# Database connection
+database_host = 'mongo'
+database_port = 27017
+database_user = 'root'
+database_password = 'example'
+database_name = 'beacon'
+database_auth_source = 'admin'
+#database_certificate = '/certs/tls-combined.pem'
+#database_cafile      = '/certs/ca.crt'
+
+# Web server configuration
+beacon_host        = '0.0.0.0'
+beacon_port        = 5050
+beacon_tls_enabled = False
+beacon_tls_client  = False
+beacon_cert        = '/certs/tls.crt'
+beacon_key         = '/certs/tls.key'
+CA_cert            = ''
+
+# Permissions server configuration
+permissions_url = 'http://beacon-permissions:5051'
+
+# IdP endpoints (OpenID Connect/Oauth2)
+idp_url = 'http://idp:8080/'
+#idp_client_id     = '${data.vault_kv_secret_v2.oidc.data["client_id"]}'
+#idp_client_secret = '${data.vault_kv_secret_v2.oidc.data["client_secret"]}'
+#idp_scope         = 'openid profile email ga4gh_passport_v1'
+#idp_authorize     = '${var.OIDC-provider}/authorize'
+#idp_access_token  = '${var.OIDC-provider}/token'
+#idp_introspection = '${var.OIDC-provider}/introspect'
+#idp_user_info     = '${var.OIDC-provider}/userinfo'
+#idp_logout        = '${var.OIDC-provider}/revoke'
+#idp_redirect_uri  = 'https://${var.hostname-beacon}.${var.ingress-base}/login'
+
+# UI
+autocomplete_limit    = 16
+autocomplete_ellipsis = '...'
+
+# Ontologies
+ontologies_folder = "ontologies"

--- a/config/gdi-starter-kit/config/beacon_reindex.sh
+++ b/config/gdi-starter-kit/config/beacon_reindex.sh
@@ -1,0 +1,3 @@
+python beacon/beacon/reindex.py
+python beacon/db/extract_filtering_terms.py
+python beacon/db/get_descendants.py

--- a/config/gdi-starter-kit/config/cohorts.yml
+++ b/config/gdi-starter-kit/config/cohorts.yml
@@ -1,0 +1,17 @@
+Heilsa_Synthetic_Data_Cohort:
+  - Case1C
+  - Case1C
+  - Case1F
+  - Case1F
+  - Case1M
+  - Case1M
+  - Case6C
+  - Case7C
+  - Case8C
+  - Case9C
+  - HG0007504
+  - HG0007505
+  - HG0007506
+  - P0007504
+  - P0007505
+  - P0007506

--- a/config/gdi-starter-kit/config/datasets.yml
+++ b/config/gdi-starter-kit/config/datasets.yml
@@ -1,0 +1,17 @@
+Heilsa_Synthetic_data :
+  - Case1C
+  - Case1C
+  - Case1F
+  - Case1F
+  - Case1M
+  - Case1M
+  - Case6C
+  - Case7C
+  - Case8C
+  - Case9C
+  - HG0007504
+  - HG0007505
+  - HG0007506
+  - P0007504
+  - P0007505
+  - P0007506

--- a/config/gdi-starter-kit/config/mongoinit/01init.js
+++ b/config/gdi-starter-kit/config/mongoinit/01init.js
@@ -1,0 +1,27 @@
+conn = new Mongo({ useUnifiedTopology: true });
+db = conn.getDB("beacon");
+
+
+// db.beacon.createIndex({ "address.zip": 1 }, { unique: false });
+// db.beacon.insert({ "address": { "city": "Paris", "zip": "123" }, "name": "Mike", "phone": "1234" });
+// db.beacon.insert({ "address": { "city": "Marsel", "zip": "321" }, "name": "Helga", "phone": "4321" });
+
+// Create collections
+
+db.createCollection("analyses");
+db.createCollection("biosamples");
+db.createCollection("cohorts");
+db.createCollection("datasets");
+db.createCollection("genomicVariations");
+db.createCollection("individuals");
+db.createCollection("runs");
+
+// Create indexes for all the entities in the database
+
+db.analyses.createIndex([('$**', 'text')]);
+db.biosamples.createIndex([('$**', 'text')]);
+db.cohorts.createIndex([('$**', 'text')]);
+db.datasets.createIndex([('$**', 'text')]);
+db.genomicVariations.createIndex([('$**', 'text')]);
+db.individuals.createIndex([('$**', 'text')]);
+db.runs.createIndex([('$**', 'text')]);

--- a/config/gdi-starter-kit/config/mongoinit/02load.sh
+++ b/config/gdi-starter-kit/config/mongoinit/02load.sh
@@ -1,0 +1,15 @@
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/datasets.json --collection datasets
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/analyses.json --collection analyses
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/biosamples.json --collection biosamples
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/cohorts.json --collection cohorts
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/individuals.json --collection individuals
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/runs.json --collection runs
+
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/genomicVariations1_IC.json --collection genomicVariations
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/genomicVariations1_trio.json --collection genomicVariations
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/genomicVariations6_IC.json --collection genomicVariations
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/genomicVariations7_IC.json --collection genomicVariations
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/genomicVariations8_IC.json --collection genomicVariations
+mongoimport --jsonArray --uri "mongodb://root:example@127.0.0.1:27017/beacon?authSource=admin" --file /data/genomicVariations9_IC.json --collection genomicVariations
+
+touch /data/db/mongoinitialized

--- a/config/gdi-starter-kit/config/public_datasets.yml
+++ b/config/gdi-starter-kit/config/public_datasets.yml
@@ -1,0 +1,2 @@
+public_datasets:
+- Heilsa_Synthetic_data

--- a/config/gdi-starter-kit/docker-compose.override.yml
+++ b/config/gdi-starter-kit/docker-compose.override.yml
@@ -103,8 +103,24 @@ services:
       htsget:
         condition: service_started
 
+  beacon:
+    networks:
+      - secure
+      - public
+    ports:
+      - "5050:5050"
+
+  db:
+    ports:
+      - 27019:27017
+    volumes:
+      - beacondb:/data/db/
+    networks:
+      - secure
+
 volumes:
   rabbitmq:
+  beacondb:
 
 networks:
   oidc:  # Persistent networks can be added to the docker host and referenced here 

--- a/config/gdi-starter-kit/docker-compose.yml
+++ b/config/gdi-starter-kit/docker-compose.yml
@@ -1,3 +1,34 @@
 include:
   - starter-kit-storage-and-interfaces/docker-compose-demo.yml
   - starter-kit-htsget/docker-compose.yml
+
+services:
+  beacon:
+    image: harbor.nbis.se/test/ejprd-gdi-beacon:1
+    depends_on:
+      db:
+        condition: service_healthy
+    working_dir: '/beacon'
+    entrypoint: ['python', '-m', 'beacon']
+    volumes:
+      - ./config/beacon_conf.py:/beacon/beacon/conf.py
+      - ./config/datasets.yml:/beacon/beacon/request/datasets.yml
+      - ./config/cohorts.yml:/beacon/beacon/request/cohorts.yml
+      - ./config/public_datasets.yml:/beacon/permissions/public_datasets.yml
+      - ./config/beacon.env:/beacon/permissions/permissions-ui/.env
+
+  db:
+    image: mongo:5
+    hostname: mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+      MONGO_INITDB_DATABASE: beacon
+    healthcheck:
+      test: ["CMD", "sh", "-c", "[ -f /data/db/mongoinitialized ] || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - ./config/mongoinit/:/docker-entrypoint-initdb.d/:ro
+      - ../../data/beaconized/:/data

--- a/data/README.md
+++ b/data/README.md
@@ -1,1 +1,0 @@
-Test data goes here

--- a/docs/beacon.md
+++ b/docs/beacon.md
@@ -1,0 +1,23 @@
+# Beacon v2
+
+1. (First time only:) Run `git submodule init`
+1. Run `git submodule update --remote` to checkout the beaconized data
+1. Start beacon: `docker compose --project-directory config/gdi-starter-kit up beacon -d`
+1. (First time only: ) Run:
+   ```
+   docker compose --project-directory config/gdi-starter-kit exec beacon python /beacon/beacon/reindex.py
+   docker compose --project-directory config/gdi-starter-kit exec beacon python beacon/db/extract_filtering_terms.py
+   docker compose --project-directory config/gdi-starter-kit exec beacon python beacon/db/get_descendants.py
+   ```
+1. Beacon should be running at port 5050, try it `curl localhost:5050/api | jq .` Check that the `response.name` is set to a suitable name.
+1. Try to search for a specific variant:
+   ```
+   curl 'http://localhost:5050/api/g_variants?referenceName=19&start=39062814&end=39062815&referenceBases=G&alternateBases=C' | jq .
+   ```
+   This should list 5 variants.
+1. Try to search for individuals matching a specific phenotype:
+   ```
+   curl 'http://localhost:5050/api/individuals?filters=NCIT:C67109' | jq .
+   ```
+   This should list 9 results in 1 dataset.
+


### PR DESCRIPTION
Test data inspired by the B1MG demonstrator ([D4.2](https://doi.org/10.5281/zenodo.7590822), [YouTube](https://www.youtube.com/watch?v=6MtIJA4xXdU)) to address #1 .

- [x] Snapshot of the smaller files and metadata from the [Rare Disease Synthetic Dataset (EGAD00001008392)](https://ega-archive.org/datasets/EGAD00001008392)
- [x] README.md and/or a script/manifest that can be used to extract/download the subset of the files and metadata from the [Rare Disease Synthetic Dataset (EGAD00001008392)](https://ega-archive.org/datasets/EGAD00001008392)
- [ ] Test data for the FAIR-in-a-Box instance including a minimal resource described according to the EJP-RD Metadata model with a Dataset, Data Distribution and Data service.
- [ ] Test data for the CARE-SM Beacon endpoint.