### PR TITLE
htsget for unencrypted data

### DIFF
--- a/config/gdi-starter-kit/config/decrypt-config.toml
+++ b/config/gdi-starter-kit/config/decrypt-config.toml
@@ -1,0 +1,25 @@
+ticket_server_addr = "0.0.0.0:8080"
+ticket_server_cors_allow_origins = "All"
+
+[[resolvers]]
+regex = "(.*)"
+substitution_string = "$1"
+
+[resolvers.object_type]
+send_encrypted_to_client = false  # if true, htsget will calculate coordinates for the encrypted case
+# Uncomment the lines below to use predefined key pairs,
+# rather than automatically generating new key pairs for each for each request
+#private_key = "/config/server-rs.sec.pem"
+#public_key = "/config/server-rs.pub.pem"
+
+[resolvers.storage]
+# The url that will be returned in the response to the client
+response_url = "http://localhost:8443/s3/"
+# forward_headers must be true in order to pass the clients token and public key to the storage endpoint
+forward_headers = true
+
+[resolvers.storage.endpoints]
+# URL to retrieve an index file from the storage
+index = "http://download:8443/s3/"
+# URL to retrieve a data file from the storage
+file = "http://download:8443/s3-encrypted/"

--- a/config/gdi-starter-kit/docker-compose.override.yml
+++ b/config/gdi-starter-kit/docker-compose.override.yml
@@ -99,12 +99,13 @@ services:
   htsgetDecrypt:
     image: harbor.nbis.se/gdi/htsget-rs:20240415
     command: ["htsget-actix", "--config", "/config/decrypt-config.toml"]
+    container_name: htsgetDecrypt
     depends_on:
       - download
       - certmaker
       - reencrypt
     ports:
-      - 8089:8080
+      - ${GDI_HTSGETDECRYPT_PORT:-8089}:8080
     environment:
       - FORMATTING_STYLE=Pretty
       - RUST_LOG=debug

--- a/config/gdi-starter-kit/docker-compose.override.yml
+++ b/config/gdi-starter-kit/docker-compose.override.yml
@@ -95,6 +95,23 @@ services:
     ports: !override
       - ${GDI_HTSGET_PORT:-8088}:8080
 
+  htsgetDecrypt:
+    image: harbor.nbis.se/gdi/htsget-rs:20240415
+    command: ["htsget-actix", "--config", "/config/decrypt-config.toml"]
+    depends_on:
+      - download
+      - certmaker
+    ports:
+      - 8089:8080
+    environment:
+      - FORMATTING_STYLE=Pretty
+      - RUST_LOG=debug
+    networks:
+      - secure # This network replaces Docker internals
+    volumes:
+      - ./config:/config
+      - certs:/certs
+
   success:
     image: hello-world
     depends_on:

--- a/config/gdi-starter-kit/docker-compose.override.yml
+++ b/config/gdi-starter-kit/docker-compose.override.yml
@@ -88,6 +88,7 @@ services:
     extra_hosts: !override []  # Don’t rely on Docker internals
     depends_on:
       - download
+      - reencrypt
     networks:
       - secure # This network replaces Docker internals
     volumes:
@@ -101,6 +102,7 @@ services:
     depends_on:
       - download
       - certmaker
+      - reencrypt
     ports:
       - 8089:8080
     environment:

--- a/docs/htsget.md
+++ b/docs/htsget.md
@@ -1,7 +1,3 @@
-> [!NOTE]
-> to be updated when
-> - branches are merged, images have final names
-
 ## Setting up from GDI Starter kit source
 1. Make sure you have the services in [storage-and-interfaces running](/docs/storage-and-interfaces.md). You might have 
    restart all services.

--- a/docs/htsget.md
+++ b/docs/htsget.md
@@ -13,18 +13,24 @@
    ```
 
 ## Testing
+The docker compose will start two instances of htsget, one for downloading encrypted data (running on port 8088 by default),
+and one for downloading decrypted data (running on port 8089 by default).
+
 Get the token from the auth service using
  ```sh
  token=$(curl -s -k https://localhost:8080/tokens | jq -r '.[0]')
  ```
 
-Read your public key. This will be used for (re-)encrypting the file before it's sent to you.
+If you want to work with encrypted data, you must have a public key.
+This will be used for (re-)encrypting the file before it's sent to you.
+Read your public key:
 ```
 pubkey=$(base64 -w0 keys/c4gh.pub.pem)
 # macOS: pubkey=$(base64 -i keys/c4gh.pub.pem)
 ```
+For the decrypted case, the header `Client-Public-Key` below can be left out.
 
-Now you should be able  make the requests to the htsget server. To request the (byte range of) chromosome 11 of the file `htsnexus_test_NA12878.bam` run:
+Now you should be able  make the requests to the htsget server. To request the (byte range of) chromosome 11 of the encrypted file `htsnexus_test_NA12878.bam` run:
  ```sh
  curl -v -H "Client-Public-Key: $pubkey" -H "Authorization: Bearer $token" -H -k "http://localhost:8088/reads/DATASET0001/htsnexus_test_NA12878?referenceName=11"
  ```


### PR DESCRIPTION
This add a htsget service that directs the user to download unencrypted data. Communication between htsget and the storage is still encrypted. Currently set to run on port 8089:
```
 $ curl -v -H "Client-Public-Key: $pubkey" -H "Authorization: Bearer $token"  -k "http://localhost:8089/variants/DATASET0001/region_vcfs/Case7_IC.reg"
{
  "htsget": {
    "format": "VCF",
    "urls": [
      {
        "url": "http://localhost:8443/s3/DATASET0001/region_vcfs/Case7_IC.reg.vcf.gz",
        "headers": {
          "Range": "bytes=0-151737",
...
```
The `url` in the response now points to the endpoint for downloading unencrypted data, and the byte ranges are calculated to match this.