### PR TITLE
Adding test data for the B1MG demonstrator (part 2)

### DIFF
--- a/docs/fair-in-a-box.md
+++ b/docs/fair-in-a-box.md
@@ -6,6 +6,8 @@ Start the services from the root of this repository:
 docker compose --project-directory config/fair-in-a-box up -d
 ```
 
+Add B1MG data for the FDP and CARE-SM Beacon endpoint.
+
 Access the services: 
 
 * FAIR Data Point Client at http://localhost:7070 ([documentation](https://fairdatapoint.readthedocs.io/en/latest/) | [default users](https://fairdatapoint.readthedocs.io/en/latest/deployment/local-deployment.html))


### PR DESCRIPTION
Test data inspired by the B1MG demonstrator ([D4.2](https://doi.org/10.5281/zenodo.7590822), [YouTube](https://www.youtube.com/watch?v=6MtIJA4xXdU)) to address #1 .

- [x] Snapshot of the smaller files and metadata from the [Rare Disease Synthetic Dataset (EGAD00001008392)](https://ega-archive.org/datasets/EGAD00001008392)
- [x] README.md and/or a script/manifest that can be used to extract/download the subset of the files and metadata from the [Rare Disease Synthetic Dataset (EGAD00001008392)](https://ega-archive.org/datasets/EGAD00001008392)
- [ ] Test data for the FAIR-in-a-Box instance including a minimal resource described according to the EJP-RD Metadata model with a Dataset, Data Distribution and Data service.
- [ ] Test data for the CARE-SM Beacon endpoint.